### PR TITLE
Add scripts for checking fsgsbase

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ We have successfully built HyperEnclave and performed tests on the following CPU
 
 #### Supported Linux kernel version
 
-- Linux kernel 5.4
-- Linux kernel 5.10
+- Linux kernel 5.10 (**Recommend**)
+- Linux kernel 5.4 with fsgsbase support
 
 
 **Updates on 2024.11:** We do not support Linux kernel 4.19 with Ubuntu OS anymore.
@@ -73,12 +73,28 @@ and install the required kernel (if necessary) by:
 $ sudo apt install wget
 $ wget https://raw.githubusercontent.com/pimlie/ubuntu-mainline-kernel.sh/master/ubuntu-mainline-kernel.sh
 $ chmod +x ubuntu-mainline-kernel.sh
-# Download and install Linux 5.4 or 5.10 kernel.
-$ sudo ./ubuntu-mainline-kernel.sh -i [5.4.0 | 5.10.0]
+# Download and install Linux 5.10 or 5.4.0 kernel.
+$ sudo ./ubuntu-mainline-kernel.sh -i [5.10.0 | 5.4.0]
 
 # Reboot the system, and we need to select the kernel in grub menu.
 $ sudo reboot
 ```
+
+For Linux kernel 5.4, **enabled_rdfsbase** kernel modules must be installed by following the instructions [here](https://github.com/occlum/enable_rdfsbase).
+
+After the Linux kernel installed, check the rdfsbase/rdgsbase is enabled:
+```bash
+$ cd scripts
+$ ./check_prereq.sh
+$ cd ..
+```
+
+And the output:
+```
+[Check FSGSBASE]: PASS
+```
+
+indicates that the rdfsgsbase/wrfsgsbase is enabled on your platform.
 
 ### Hardware requirements
 - **CPU & Virtualization**: An Intel, AMD, or HYGON processor that supports and has enabled virtualization (VMX for Intel, AMD-V for AMD) in the BIOS.
@@ -239,7 +255,7 @@ Reference to `demos/RemoteAttestation` for more information.
 
 #### Occlum demos
 
-You can also run TEE applications developed based on [Occlum](https://github.com/occlum/occlum). All the Occlum demos are preinstalled in our docker image at `/root/occlum/demos`. Before having a try on them, install [enable_rdfsbase kernel module](https://github.com/occlum/enable_rdfsbase) to **make sure `fsgsbase` is enabled**.
+You can also run TEE applications developed based on [Occlum](https://github.com/occlum/occlum). All the Occlum demos are preinstalled in our docker image at `/root/occlum/demos`.
 
 We take `hello_c` as an example. (Command should be done inside Docker container):
 ```bash

--- a/scripts/build_and_install_hyperenclave.sh
+++ b/scripts/build_and_install_hyperenclave.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+SCRIPT_DIR=$(dirname "$0")
+cd $SCRIPT_DIR/..
+
 check_sme()
 {
 	if lscpu | grep -wq "sme"; then  # Use -w for word matching

--- a/scripts/check_fsgsbase.c
+++ b/scripts/check_fsgsbase.c
@@ -1,0 +1,72 @@
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <signal.h>
+#include <assert.h>
+#include <string.h>
+#include <ucontext.h>
+#include <setjmp.h>
+#include <stdlib.h>
+#include <errno.h>
+
+#define RC 0xffff
+static jmp_buf env_buf;
+
+static void handle_sigill(int num) {
+    assert(num == SIGILL);
+
+    longjmp(env_buf, RC);
+}
+
+int check_fsgsbase_enablement(void) {
+    int gs_read_data = 0;
+    int gs_write_data = 0x0f;
+    int __seg_gs *offset_ptr = 0;   // offset relative to GS. support since gcc-6
+
+    sighandler_t handler_orig = signal(SIGILL, handle_sigill);
+    if (handler_orig == SIG_ERR) {
+        fprintf(stderr, "registering signal handler failed, errno = %d", errno);
+        return -1;
+    }
+
+    int ret = setjmp(env_buf);
+    if (ret == RC) {
+        // return from SIGILL handler
+        fprintf(stderr, "\tSIGILL Caught !\n");
+        return -1;
+    }
+    if (ret != 0) {
+        fprintf(stderr, "setjmp failed");
+        return -1;
+    }
+
+    // Check if kernel supports FSGSBASE
+    asm("rdgsbase %0" :: "r" (&gs_read_data));
+    asm("wrgsbase %0" :: "r" (&gs_write_data));
+
+    if (*offset_ptr != 0x0f) {
+        fprintf(stderr, "GS register data not match\n");
+        return -1;
+    };
+
+    // Restore the GS register and original signal handler
+    asm("wrgsbase %0" :: "r" (&gs_read_data));
+    handler_orig = signal(SIGILL, handler_orig);
+    if (handler_orig == SIG_ERR) {
+        fprintf(stderr, "restoring default signal handler failed, errno = %d", errno);
+        return -1;
+    }
+
+    return 0;
+}
+
+int main() {
+    int ret;
+
+    if ((ret = check_fsgsbase_enablement()) == 0) {
+        printf("[Check fsgsbase]: PASS\n");
+    } else {
+        printf("[Check fsgsbase]: FAILED\n");
+    }
+
+    return ret;
+}

--- a/scripts/check_prereq.sh
+++ b/scripts/check_prereq.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC="\e[0m"
+
+check_fsgsbase()
+{
+	local SCRIPT_DIR=$(cd $(dirname $0); pwd)
+	cd $SCRIPT_DIR
+
+	gcc -o check_fsgsbase check_fsgsbase.c
+	./check_fsgsbase &> /dev/null
+	return_value=$?
+	rm check_fsgsbase
+	if [ "$return_value" -eq 0 ]; then
+		echo -e "$GREEN [Check FSGSBASE]: PASS $NC"
+	else
+		echo -e "$RED [Check FSGSBASE]: FAILED $NC"
+		exit 1
+	fi
+}
+
+# Check FSGSBASE is enabled on the current platform
+check_fsgsbase

--- a/scripts/start_hyperenclave.sh
+++ b/scripts/start_hyperenclave.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+SCRIPT_DIR=$(cd $(dirname $0); pwd)
+
+source $SCRIPT_DIR/check_prereq.sh
+
 CMDLINE=/proc/cmdline
 
 YELLOW="\e[33m"
@@ -48,6 +52,6 @@ if [ "$res" = "ERROR" ];then
 	echo "ERROR. Please use correct memmap parameter: memmap=nn[KMG]$ss[KMG]"
 else
 	feature_mask=0x302
-	sudo insmod ../../hyperenclave-driver/driver/hyper_enclave.ko str_memmap=$res feature_mask=$feature_mask
+	sudo insmod $SCRIPT_DIR/../../hyperenclave-driver/driver/hyper_enclave.ko str_memmap=$res feature_mask=$feature_mask
 	sudo sysctl dev.hyper_enclave.enabled=1
 fi


### PR DESCRIPTION
- Add scripts to check whether fsgsbase is enabled;
- Add instructions to install "enable_fsgsbase" kernel module before installing HyperEnclave.


Test:
fsgsbase is not disabled:
<img width="247" alt="截屏2024-11-20 12 58 58" src="https://github.com/user-attachments/assets/e118b655-a496-476e-8cd6-be0dbded65b1">

fsgsbase is enabled:
<img width="262" alt="截屏2024-11-20 13 00 29" src="https://github.com/user-attachments/assets/56d3925e-bda0-422b-a8b6-a92d05ab3fcc">

Such change can detect that rdfsgsbase is not enabled (https://github.com/asterinas/hyperenclave/issues/17)
